### PR TITLE
cpc-charter: do not dictate how the Node.js board member is elected

### DIFF
--- a/proposals/stage-2/CPC_CHARTER/CPC-CHARTER.md
+++ b/proposals/stage-2/CPC_CHARTER/CPC-CHARTER.md
@@ -247,7 +247,7 @@ processes for filling this seat will be as follows:
 
 * As a constellation member of the OpenJS Foundation, the Node.js project
   will elect one Board representative from either the Technical Steering Committee (TSC) or
-  Community Committee. The representative will be selected according to a process
+  Community Committee (CommComm). The representative will be selected according to a process
 defined by the TSC and CommComm. 
 
 As described in the [Elections][] section a multiple candidate method

--- a/proposals/stage-2/CPC_CHARTER/CPC-CHARTER.md
+++ b/proposals/stage-2/CPC_CHARTER/CPC-CHARTER.md
@@ -246,7 +246,7 @@ For the first year after the formation of the OpenJS Foundation, the
 processes for filling this seat will be as follows:
 
 * As a constellation member of the OpenJS Foundation, the Node.js project
-  will elect one Board representative from either the TSC or
+  will elect one Board representative from either the Technical Steering Committee (TSC) or
   Community Committee. The representative will be selected according to a process
 defined by the TSC and CommComm. 
 

--- a/proposals/stage-2/CPC_CHARTER/CPC-CHARTER.md
+++ b/proposals/stage-2/CPC_CHARTER/CPC-CHARTER.md
@@ -248,7 +248,7 @@ processes for filling this seat will be as follows:
 * As a constellation member of the OpenJS Foundation, the Node.js project
   will elect one Board representative from either the TSC or
   Community Committee. The representative will be selected according to a process
-defined by TSC and CommComm. 
+defined by the TSC and CommComm. 
 
 As described in the [Elections][] section a multiple candidate method
 will be be used for the voting for the first and second board members.

--- a/proposals/stage-2/CPC_CHARTER/CPC-CHARTER.md
+++ b/proposals/stage-2/CPC_CHARTER/CPC-CHARTER.md
@@ -248,7 +248,7 @@ processes for filling this seat will be as follows:
 * As a constellation member of the OpenJS Foundation, the Node.js project
   will elect one Board representative from either the Technical Steering Committee (TSC) or
   Community Committee (CommComm). The representative will be selected according to a process
-defined by the TSC and CommComm. 
+  defined by the TSC and CommComm. 
 
 As described in the [Elections][] section a multiple candidate method
 will be be used for the voting for the first and second board members.

--- a/proposals/stage-2/CPC_CHARTER/CPC-CHARTER.md
+++ b/proposals/stage-2/CPC_CHARTER/CPC-CHARTER.md
@@ -248,7 +248,7 @@ processes for filling this seat will be as follows:
 * As a constellation member of the OpenJS Foundation, the Node.js project
   will elect one Board representative from either the TSC or
   Community Committee. The representative will be selected according to a process
-  defined by TSC or CommComm. 
+defined by TSC and CommComm. 
 
 As described in the [Elections][] section a multiple candidate method
 will be be used for the voting for the first and second board members.

--- a/proposals/stage-2/CPC_CHARTER/CPC-CHARTER.md
+++ b/proposals/stage-2/CPC_CHARTER/CPC-CHARTER.md
@@ -247,8 +247,8 @@ processes for filling this seat will be as follows:
 
 * As a constellation member of the OpenJS Foundation, the Node.js project
   will elect one Board representative from either the TSC or
-  Community Committee. The representative will be selected through a vote
-  of the members of the Node.js organization. 
+  Community Committee. The representative will be selected according to a process
+  defined by TSC or CommComm. 
 
 As described in the [Elections][] section a multiple candidate method
 will be be used for the voting for the first and second board members.


### PR DESCRIPTION
I think the CPC Charter is too specific in how the Node.js organization is going to elect its Board member for the first year. I think this should be left to the TSC and CommComm to decide.