### PR TITLE
Substitute repetitions of OpenJS Foundation in docs

### DIFF
--- a/INDIVIDUAL_MEMBERSHIP.md
+++ b/INDIVIDUAL_MEMBERSHIP.md
@@ -8,7 +8,7 @@ To engage as many community members as possible, the Individual Membership progr
 
 The Individual Membership program will roll out in two phases. 
 
-Phase 1: At launch, the program will only have a single tier. This will provide the OpenJS Foundation projects early validation of the program’s utility, give program developers the opportunity to receive feedback on tooling and workflow from members, and ease initial launch overhead for the implementers.
+Phase 1: At launch, the program will only have a single tier. This will provide the OpenJS Foundation, hereinafter referred to as the "Foundation", projects early validation of the program’s utility, give program developers the opportunity to receive feedback on tooling and workflow from members, and ease initial launch overhead for the implementers.
 
 Phase 2: The long term goal of the projects will be to deliver three membership tiers, as described below. The initial membership offering would then be known as Bronze Membership, followed by the addition of the two higher tiers in terms of perks.The delay in Silver and Gold Membership launch allow the program time to recruit corporate member perks and mature enough to provide value.
 
@@ -28,21 +28,21 @@ be determined by the CPC.
 
 #### Rollout Target: Q4 2019
 
-The affordability of this member level allows for folks who are excited about OpenJS Foundation projects to feel part of the OpenJS Foundation without putting the barrier to entry too high. This membership level affords participants:
+The affordability of this member level allows for folks who are excited about Foundation projects to feel part of the Foundation without putting the barrier to entry too high. This membership level affords participants:
 
-1. The OpenJS Foundation member badge – an exclusive digital membership badge and sticker 
-2. Public “thank you” on the OpenJS Foundation website 
+1. The Foundation member badge – an exclusive digital membership badge and sticker 
+2. Public “thank you” on the Foundation website 
 3. Invitation to a quarterly town hall meeting with the CPC 
 4. Bi-monthly town hall meeting with individual representation champion 
 5. Access to the mailing list with monthly update 
-6. Access to exclusive Individual Membership swag in the OpenJS Foundation Store purchasable at cost (ex: clothing, pins, stickers) 
+6. Access to exclusive Individual Membership swag in the Foundation Store purchasable at cost (ex: clothing, pins, stickers) 
 7. Guaranteed discount to Foundation-run events
 
 ### Silver Member ($60/yr) 
 
 #### Rollout Target: Q1 2020
 
-This membership level targets participants excited to become more involved with industry tools and services by connecting with OpenJS Foundation Corporate Member companies on a deeper level. This level affords participants all the benefits of Bronze Membership as well as:
+This membership level targets participants excited to become more involved with industry tools and services by connecting with Foundation Corporate Member companies on a deeper level. This level affords participants all the benefits of Bronze Membership as well as:
 
 1. Access to Corporate Member perks (similar to GitHub’s [Student Developer Pack](https://education.github.com/pack)) 
     1. Ex: Three free months of LinkedIn Learning 
@@ -56,7 +56,7 @@ This membership level targets participants excited to become more involved with 
 
 A Gold Membership is for community members eager to engage closer with project administration and governance. This level affordes participants all the benefits of Silver Membership, as well as:
 
-1. A yearly town hall style meet and greet with OpenJS Foundation Board members 
+1. A yearly town hall style meet and greet with Foundation Board members 
 2. 25% discount to Foundation events.
 3. TBD
   
@@ -65,14 +65,14 @@ A Gold Membership is for community members eager to engage closer with project a
 - Access to an engaged audience of Node.js users 
 - Corporate members are able to provide exclusive swag/resources/credits to the membership 
 
-## Benefits to the OpenJS Foundation
+## Benefits to the Foundation
 
-- Better decision making for strategy and road map to ensure the success and sustainability of the OpenJS Foundation through access to engaged OpenJS Foundation project users for regular feedback 
+- Better decision making for strategy and road map to ensure the success and sustainability of the Foundation through access to engaged Foundation project users for regular feedback 
 - Increase the number of promoters for the foundation efforts through building trust and reputation of meeting the needs of the ecosystem 
   
 ## Required feedback gathering on a regular cadence from members 
 
-The Individual Membership program moving forward must understand the demographics of those being served. A voluntary self-reporting of demographics from existing collaborators and engaged users will go a long way to improving the OpenJS Foundation feedback loop. It is recommended that an assigned person from the OpenJS Foundation executive team be responsible for coordinating this effort directly in collaboration with the CPC. This ensures that once we are connected to engaged users, we are hearing input, acting on it, and being held accountable to needs.
+The Individual Membership program moving forward must understand the demographics of those being served. A voluntary self-reporting of demographics from existing collaborators and engaged users will go a long way to improving the Foundation feedback loop. It is recommended that an assigned person from the Foundation executive team be responsible for coordinating this effort directly in collaboration with the CPC. This ensures that once we are connected to engaged users, we are hearing input, acting on it, and being held accountable to needs.
 
 The continued engagement model will include first-contact communications and highlights to members before public notice and gives the foundation the opportunity to convert the transactional relationship to caring members. 
 
@@ -81,7 +81,7 @@ The continued engagement model will include first-contact communications and hig
 *$2100 annually*
 Migrate over old system due to lack of interoperability and maintenance.
 
-Tendenci is an open source membership management platform. $2028 per year. Cost increases to $249 per month once we hit 1000-5000 member range. Price upgrade gives us more processing power(so we could technically remain on the lower tier because it is not per-user cost and instead based off of the performance we want our users to experience). Manages signups, renewals, emails to members (currently not possible within a single system for us), news, events. Has the potential to add corporate and individual member value with the batteries-included offering, and doesn’t cost any more for these features. Example in the wild: [http://www.sfbig.org/](http://www.sfbig.org/]. Requires minimal admin IT work and an easy-to-navigate GUI that the entire OpenJS Foundation internal team could access/administer along with projects members.  
+Tendenci is an open source membership management platform. $2028 per year. Cost increases to $249 per month once we hit 1000-5000 member range. Price upgrade gives us more processing power(so we could technically remain on the lower tier because it is not per-user cost and instead based off of the performance we want our users to experience). Manages signups, renewals, emails to members (currently not possible within a single system for us), news, events. Has the potential to add corporate and individual member value with the batteries-included offering, and doesn’t cost any more for these features. Example in the wild: [http://www.sfbig.org/](http://www.sfbig.org/]. Requires minimal admin IT work and an easy-to-navigate GUI that the entire Foundation internal team could access/administer along with projects members.  
   
 ## Voting System for elections
 CIVS

--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -1,7 +1,7 @@
 ## I. Overview
-This governance policy describes how an open source project can formally join the Foundation via the [Project Proposal Process](). It describes the [Stages]() a project may be admitted under and what the criteria and expectations are for a given stage, as well as the acceptance criteria for a project to move from one stage to another. It also describes the [Annual Review Process]() through which those changes will be evaluated and made. 
+This governance policy describes how an open source project can formally join the Foundation, hereinafter referred to as the "Foundation", via the [Project Proposal Process](). It describes the [Stages]() a project may be admitted under and what the criteria and expectations are for a given stage, as well as the acceptance criteria for a project to move from one stage to another. It also describes the [Annual Review Process]() through which those changes will be evaluated and made. 
 
-Project progression - movement from one stage to another - allows projects to particpate at the level that is most appropriate for them given where they are in their lifecycle. Regardless of stage, all OpenJS Foundation projects benefit from a deepened alignment with existing projects, and access to mentorship, support, and foundation resources such as the travel fund.
+Project progression - movement from one stage to another - allows projects to particpate at the level that is most appropriate for them given where they are in their lifecycle. Regardless of stage, all Foundation projects benefit from a deepened alignment with existing projects, and access to mentorship, support, and foundation resources such as the travel fund.
 
 For more information about how your project can benefit from Foundation membership and services, please see [TBD Document]().
 
@@ -10,14 +10,14 @@ This proposal has been modified from the [CNCF process documentation](https://gi
 ## II. Project Proposal Process
 
 ### Introduction
-This governance policy sets forth the proposal process for projects to be accepted into the OpenJS Foundation. The process is the same for both existing projects which seek to move into the OpenJS Foundation, and new projects to be formed within the OpenJS Foundation.
+This governance policy sets forth the proposal process for projects to be accepted into the Foundation. The process is the same for both existing projects which seek to move into the Foundation, and new projects to be formed within the Foundation.
 
 ### Project Proposal Requirements
-Projects must be proposed via GitHub. Project proposals submitted to the OpenJS Foundation must provide the following information to the best of their ability:
+Projects must be proposed via GitHub. Project proposals submitted to the Foundation must provide the following information to the best of their ability:
 
 * name of project
 * project description (what it does, why it is valuable, origin and history)
-* statement on alignment with OpenJS Foundation charter mission
+* statement on alignment with Foundation charter mission
 * link to *current* Code of Conduct
 * sponsor from CPC, if identified (a sponsor helps mentor projects)
 * project license 
@@ -36,41 +36,41 @@ Projects must be proposed via GitHub. Project proposals submitted to the OpenJS 
 
 ### Project Acceptance Process
 * Projects are required to present their proposal at a CPC meeting
-* The CPC may ask for changes to bring the project into better alignment with the OpenJS Foundation (adding a governance document to a repository or adopting a more stringent Code of Conduct, for example).
+* The CPC may ask for changes to bring the project into better alignment with the Foundation (adding a governance document to a repository or adopting a more stringent Code of Conduct, for example).
  * The project will need to make these changes in order to progress further.
 * Projects get accepted via a 2/3 supermajority vote of the CPC.
 * The proposal document will be finalized as a project charter. This charter document must be included in the project's main repository.
 * The CPC will determine the appropriate initial stage for the project. The project can apply for a different stage via the review process. 
 
 ## III. Stages - Definitions & Expectations
-Every OpenJS Foundation project has an associated maturity level. Proposed OpenJS Foundation projects should state their preferred maturity level. Projects of all maturities have access to OpenJS Foundation resources.
+Every Foundation project has an associated maturity level. Proposed Foundation projects should state their preferred maturity level. Projects of all maturities have access to Foundation resources.
 
-All OpenJS Foundation projects may attend CPC meetings and contribute work regardless of their stage. 
+All Foundation projects may attend CPC meetings and contribute work regardless of their stage. 
 
 *note: all stage names are tbd pending outcome of [#44](https://github.com/nodejs/bootstrap/issues/44#issuecomment-440026298)*
 
 ### At Large Projects (formerly 'Sandbox')
 **Definition** 
 
-At Large projects are projects which the CPC believes are, or have the potential to be, important to the ecosystem of Top-Level Projects or the JS ecosystem as a whole. They may be early-stage projects just getting started, or they may be long-established projects with minimal resource needs. The At Large stage provides a beneficial, neutral home for these projects in order to foster collaborative development and provide a path to deeper alignment with other OpenJS Foundation projects via the graduation process.
+At Large projects are projects which the CPC believes are, or have the potential to be, important to the ecosystem of Top-Level Projects or the JS ecosystem as a whole. They may be early-stage projects just getting started, or they may be long-established projects with minimal resource needs. The At Large stage provides a beneficial, neutral home for these projects in order to foster collaborative development and provide a path to deeper alignment with other Foundation projects via the graduation process.
 
 **Examples**
 
-1. New projects that are designed to extend one or more OpenJS Foundation projects with functionality or interoperability libraries. 
-1. Independent projects that fit the OpenJS Foundation mission and provide potential for a novel approach to existing functional areas (or are an attempt to meet an unfulfilled need).
-1. Projects commissioned or sanctioned by the OpenJS Foundation.
-1. Any project that realistically intends to join the OpenJS Foundation Incubation or Top Level Stages in the future and wishes to lay the foundations for that transition.
+1. New projects that are designed to extend one or more Foundation projects with functionality or interoperability libraries. 
+1. Independent projects that fit the Foundation mission and provide potential for a novel approach to existing functional areas (or are an attempt to meet an unfulfilled need).
+1. Projects commissioned or sanctioned by the Foundation.
+1. Any project that realistically intends to join the Foundation Incubation or Top Level Stages in the future and wishes to lay the foundations for that transition.
 
 **Expectations**
 
-End users should evaluate At Large projects with care, as this stage does not set requirements for community size, governance, or production readiness. At Large projects will receive minimal marketing support from the OpenJS Foundation. Projects will be reviewed on an annual basis; they may also request a status review by submitting a report to the CPC.
+End users should evaluate At Large projects with care, as this stage does not set requirements for community size, governance, or production readiness. At Large projects will receive minimal marketing support from the Foundation. Projects will be reviewed on an annual basis; they may also request a status review by submitting a report to the CPC.
 
 **Acceptance Criteria**
 
 To be considered for the At Large Stage, the project must meet the following requirements:
 * 2 CPC sponsors to champion the project & provide mentorship as needed
 * A presentation to at the meeting of the CPC
-* Adherence to the OpenJS Foundation IP Policy
+* Adherence to the Foundation IP Policy
 * Upon acceptance, At Large projects must list their status prominently on website/readme
 
 ### Growth Stage (formerly 'Incubating')
@@ -125,7 +125,7 @@ To graduate from At Large or Growth status, or for a new project to join as an I
  * Have a defined governing body of at least 5 or more members (owners and core maintainers), of which no more than 1/3 is affiliated with the same employer. In the case there are 5 governing members, 2 may be from the same employer. 
  * Have a documented and publicly accessible description of the project's governance, decision-making, and release processes.
  * Have a healthy number of committers from at least two organizations. A committer is defined as someone with the commit bit; i.e., someone who can accept contributions to some or all of the project.
- * Adopt the OpenJS Foundation Code of Conduct.
+ * Adopt the Foundation Code of Conduct.
  * Explicitly define a project governance and committer process. This is preferably laid out in a GOVERNANCE.md file and references a CONTRIBUTING.md and OWNERS.md file showing the current and emeritus committers.
  * Have a public list of project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the project website).
  * Other metrics as defined by the applying Project during the application process in cooperation with the CPC.
@@ -135,7 +135,7 @@ To graduate from At Large or Growth status, or for a new project to join as an I
 ### Emeritus Stage
 **Definition**
 
-Emeritus projects are projects which the maintainers feel have reached or are nearing end-of-life. Emeritus projects have contributed to the ecosystem, but are not necessarily recommended for modern development as there may be more actively maintained choices. The OpenJS Foundation appreciates the contributions of these projects and their communities, and the role they have played in moving the ecosystem forward. 
+Emeritus projects are projects which the maintainers feel have reached or are nearing end-of-life. Emeritus projects have contributed to the ecosystem, but are not necessarily recommended for modern development as there may be more actively maintained choices. The Foundation appreciates the contributions of these projects and their communities, and the role they have played in moving the ecosystem forward. 
 
 **Examples**
 

--- a/PROJECT_PROGRESSION.md
+++ b/PROJECT_PROGRESSION.md
@@ -1,5 +1,5 @@
 ## I. Overview
-This governance policy describes how an open source project can formally join the Foundation, hereinafter referred to as the "Foundation", via the [Project Proposal Process](). It describes the [Stages]() a project may be admitted under and what the criteria and expectations are for a given stage, as well as the acceptance criteria for a project to move from one stage to another. It also describes the [Annual Review Process]() through which those changes will be evaluated and made. 
+This governance policy describes how an open source project can formally join the OpenJS Foundation, hereinafter referred to as the "Foundation", via the [Project Proposal Process](). It describes the [Stages]() a project may be admitted under and what the criteria and expectations are for a given stage, as well as the acceptance criteria for a project to move from one stage to another. It also describes the [Annual Review Process]() through which those changes will be evaluated and made. 
 
 Project progression - movement from one stage to another - allows projects to particpate at the level that is most appropriate for them given where they are in their lifecycle. Regardless of stage, all Foundation projects benefit from a deepened alignment with existing projects, and access to mentorship, support, and foundation resources such as the travel fund.
 

--- a/proposals/stage-1/CODE_OF_CONDUCT/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md
+++ b/proposals/stage-1/CODE_OF_CONDUCT/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md
@@ -1,15 +1,16 @@
 # Foundation Code of Conduct Requirements
 
 It is important that there be a Code of Conduct (CoC) which
-is documented and enforced for the OpenJS Foundation and the
+is documented and enforced for the OpenJS Foundation, 
+hereinafter referred to as the "Foundation", and the
 projects within it. This document defines the requirements
-for a CoC for the OpenJS Foundation and the projects which are part
+for a CoC for the Foundation and the projects which are part
 of the foundation.
 
 
 ## Code of Conduct
 
-The OpenJS Foundation has adopted the
+The Foundation has adopted the
 [Contributor Covenant v1.4.1](https://www.contributor-covenant.org/version/1/4/code-of-conduct.md)
 as its code of conduct and it applies to all foundation activities and spaces. In
 addition, projects joining the foundation are required to adopt this code of conduct

--- a/proposals/stage-3/INDIVIDUAL_MEMBERSHIP/INDIVIDUAL_MEMBERSHIP.md
+++ b/proposals/stage-3/INDIVIDUAL_MEMBERSHIP/INDIVIDUAL_MEMBERSHIP.md
@@ -8,7 +8,7 @@ To engage as many community members as possible, the Individual Membership progr
 
 The Individual Membership program will roll out in two phases. 
 
-Phase 1: At launch, the program will only have a single tier. This will provide the OpenJS Foundation projects early validation of the program’s utility, give program developers the opportunity to receive feedback on tooling and workflow from members, and ease initial launch overhead for the implementers.
+Phase 1: At launch, the program will only have a single tier. This will provide the OpenJS Foundation, hereinafter referred to as the "Foundation", projects early validation of the program’s utility, give program developers the opportunity to receive feedback on tooling and workflow from members, and ease initial launch overhead for the implementers.
 
 Phase 2: The long term goal of the projects will be to deliver three membership tiers, as described below. The initial membership offering would then be known as Bronze Membership, followed by the addition of the two higher tiers in terms of perks.The delay in Silver and Gold Membership launch allow the program time to recruit corporate member perks and mature enough to provide value.
 
@@ -28,21 +28,21 @@ be determined by the CPC.
 
 #### Rollout Target: Q4 2019
 
-The affordability of this member level allows for folks who are excited about OpenJS Foundation projects to feel part of the OpenJS Foundation without putting the barrier to entry too high. This membership level affords participants:
+The affordability of this member level allows for folks who are excited about Foundation projects to feel part of the Foundation without putting the barrier to entry too high. This membership level affords participants:
 
-1. The OpenJS Foundation member badge – an exclusive digital membership badge and sticker 
-2. Public “thank you” on the OpenJS Foundation website 
+1. The Foundation member badge – an exclusive digital membership badge and sticker 
+2. Public “thank you” on the Foundation website 
 3. Invitation to a quarterly town hall meeting with the CPC 
 4. Bi-monthly town hall meeting with individual representation champion 
 5. Access to the mailing list with monthly update 
-6. Access to exclusive Individual Membership swag in the OpenJS Foundation Store purchasable at cost (ex: clothing, pins, stickers) 
+6. Access to exclusive Individual Membership swag in the Foundation Store purchasable at cost (ex: clothing, pins, stickers) 
 7. Guaranteed discount to Foundation-run events
 
 ### Silver Member ($60/yr) 
 
 #### Rollout Target: Q1 2020
 
-This membership level targets participants excited to become more involved with industry tools and services by connecting with OpenJS Foundation Corporate Member companies on a deeper level. This level affords participants all the benefits of Bronze Membership as well as:
+This membership level targets participants excited to become more involved with industry tools and services by connecting with Foundation Corporate Member companies on a deeper level. This level affords participants all the benefits of Bronze Membership as well as:
 
 1. Access to Corporate Member perks (similar to GitHub’s [Student Developer Pack](https://education.github.com/pack)) 
     1. Ex: Three free months of LinkedIn Learning 
@@ -56,7 +56,7 @@ This membership level targets participants excited to become more involved with 
 
 A Gold Membership is for community members eager to engage closer with project administration and governance. This level affordes participants all the benefits of Silver Membership, as well as:
 
-1. A yearly town hall style meet and greet with OpenJS Foundation Board members 
+1. A yearly town hall style meet and greet with Foundation Board members 
 2. 25% discount to Foundation events.
 3. TBD
   
@@ -65,14 +65,14 @@ A Gold Membership is for community members eager to engage closer with project a
 - Access to an engaged audience of Node.js users 
 - Corporate members are able to provide exclusive swag/resources/credits to the membership 
 
-## Benefits to the OpenJS Foundation
+## Benefits to the Foundation
 
-- Better decision making for strategy and road map to ensure the success and sustainability of the OpenJS Foundation through access to engaged OpenJS Foundation project users for regular feedback 
+- Better decision making for strategy and road map to ensure the success and sustainability of the Foundation through access to engaged Foundation project users for regular feedback 
 - Increase the number of promoters for the foundation efforts through building trust and reputation of meeting the needs of the ecosystem 
   
 ## Required feedback gathering on a regular cadence from members 
 
-The Individual Membership program moving forward must understand the demographics of those being served. A voluntary self-reporting of demographics from existing collaborators and engaged users will go a long way to improving the OpenJS Foundation feedback loop. It is recommended that an assigned person from the OpenJS Foundation executive team be responsible for coordinating this effort directly in collaboration with the CPC. This ensures that once we are connected to engaged users, we are hearing input, acting on it, and being held accountable to needs.
+The Individual Membership program moving forward must understand the demographics of those being served. A voluntary self-reporting of demographics from existing collaborators and engaged users will go a long way to improving the Foundation feedback loop. It is recommended that an assigned person from the Foundation executive team be responsible for coordinating this effort directly in collaboration with the CPC. This ensures that once we are connected to engaged users, we are hearing input, acting on it, and being held accountable to needs.
 
 The continued engagement model will include first-contact communications and highlights to members before public notice and gives the foundation the opportunity to convert the transactional relationship to caring members. 
 
@@ -81,7 +81,7 @@ The continued engagement model will include first-contact communications and hig
 *$2100 annually*
 Migrate over old system due to lack of interoperability and maintenance.
 
-Tendenci is an open source membership management platform. $2028 per year. Cost increases to $249 per month once we hit 1000-5000 member range. Price upgrade gives us more processing power(so we could technically remain on the lower tier because it is not per-user cost and instead based off of the performance we want our users to experience). Manages signups, renewals, emails to members (currently not possible within a single system for us), news, events. Has the potential to add corporate and individual member value with the batteries-included offering, and doesn’t cost any more for these features. Example in the wild: [http://www.sfbig.org/](http://www.sfbig.org/]. Requires minimal admin IT work and an easy-to-navigate GUI that the entire OpenJS Foundation internal team could access/administer along with projects members.  
+Tendenci is an open source membership management platform. $2028 per year. Cost increases to $249 per month once we hit 1000-5000 member range. Price upgrade gives us more processing power(so we could technically remain on the lower tier because it is not per-user cost and instead based off of the performance we want our users to experience). Manages signups, renewals, emails to members (currently not possible within a single system for us), news, events. Has the potential to add corporate and individual member value with the batteries-included offering, and doesn’t cost any more for these features. Example in the wild: [http://www.sfbig.org/](http://www.sfbig.org/]. Requires minimal admin IT work and an easy-to-navigate GUI that the entire Foundation internal team could access/administer along with projects members.  
   
 ## Voting System for elections
 CIVS

--- a/proposals/stage-3/INDIVIDUAL_MEMBERSHIP/README.md
+++ b/proposals/stage-3/INDIVIDUAL_MEMBERSHIP/README.md
@@ -6,7 +6,7 @@
 
 ### Description
 
-The projects of the OpenJS Foundation should strive to feel more engaging and welcoming. The Individual Membership program brings together OpenJS Foundation projects contributors and users – who are not current contributors – through increased participation, solicited input, and first access to some OpenJS Foundation provided benefits. This program codifies a relationship with our ecosystem, and provides an opportunity for the OpenJS Foundation, and member companies, to connect with engaged community members through systematic communication building.
+The projects of the OpenJS Foundation, hereinafter referred to as the "Foundation", should strive to feel more engaging and welcoming. The Individual Membership program brings together Foundation projects contributors and users – who are not current contributors – through increased participation, solicited input, and first access to some Foundation provided benefits. This program codifies a relationship with our ecosystem, and provides an opportunity for the Foundation, and member companies, to connect with engaged community members through systematic communication building.
 
 ### Required Resources
 
@@ -17,7 +17,7 @@ What resources would be needed to execute it?
 
 ### Who would be responsible?
 
-The CPC would own the maintenance and sustainability of the programs with power to delegate, and would be aided by the Executive group with resources of the OpenJS Foundation to execute.
+The CPC would own the maintenance and sustainability of the programs with power to delegate, and would be aided by the Executive group with resources of the Foundation to execute.
 
 ### How would success be measured?
 
@@ -33,7 +33,7 @@ With the historical data we have regarding individual membership in Node.js, if 
 
 *The goals of the proposed program include:*
 
-- To give a voice and direction to a larger and different group than core collaborators of projects. To feel bought into the OpenJS Foundation. 
+- To give a voice and direction to a larger and different group than core collaborators of projects. To feel bought into the Foundation. 
 - To have a visible association with the foundation 
 - They see direct benefit through the swag, resources, etc. 
 

--- a/proposals/stage-3/PROJECT_PROGRESSION/PROJECT_PROGRESSION.md
+++ b/proposals/stage-3/PROJECT_PROGRESSION/PROJECT_PROGRESSION.md
@@ -1,7 +1,7 @@
 ## I. Overview
-This governance policy describes how an open source project can formally join the Foundation via the [Project Proposal Process](). It describes the [Stages]() a project may be admitted under and what the criteria and expectations are for a given stage, as well as the acceptance criteria for a project to move from one stage to another. It also describes the [Annual Review Process]() through which those changes will be evaluated and made. 
+This governance policy describes how an open source project can formally join the OpenJS Foundation, hereinafter referred to as the "Foundation", via the [Project Proposal Process](). It describes the [Stages]() a project may be admitted under and what the criteria and expectations are for a given stage, as well as the acceptance criteria for a project to move from one stage to another. It also describes the [Annual Review Process]() through which those changes will be evaluated and made. 
 
-Project progression - movement from one stage to another - allows projects to particpate at the level that is most appropriate for them given where they are in their lifecycle. Regardless of stage, all OpenJS Foundation projects benefit from a deepened alignment with existing projects, and access to mentorship, support, and foundation resources such as the travel fund.
+Project progression - movement from one stage to another - allows projects to particpate at the level that is most appropriate for them given where they are in their lifecycle. Regardless of stage, all Foundation projects benefit from a deepened alignment with existing projects, and access to mentorship, support, and foundation resources such as the travel fund.
 
 For more information about how your project can benefit from Foundation membership and services, please see [TBD Document]().
 
@@ -10,14 +10,14 @@ This proposal has been modified from the [CNCF process documentation](https://gi
 ## II. Project Proposal Process
 
 ### Introduction
-This governance policy sets forth the proposal process for projects to be accepted into the OpenJS Foundation. The process is the same for both existing projects which seek to move into the OpenJS Foundation, and new projects to be formed within the OpenJS Foundation.
+This governance policy sets forth the proposal process for projects to be accepted into the Foundation. The process is the same for both existing projects which seek to move into the Foundation, and new projects to be formed within the Foundation.
 
 ### Project Proposal Requirements
-Projects must be proposed via GitHub. Project proposals submitted to the OpenJS Foundation must provide the following information to the best of their ability:
+Projects must be proposed via GitHub. Project proposals submitted to the Foundation must provide the following information to the best of their ability:
 
 * name of project
 * project description (what it does, why it is valuable, origin and history)
-* statement on alignment with OpenJS Foundation charter mission
+* statement on alignment with Foundation charter mission
 * link to *current* Code of Conduct
 * sponsor from CPC, if identified (a sponsor helps mentor projects)
 * project license 
@@ -36,41 +36,41 @@ Projects must be proposed via GitHub. Project proposals submitted to the OpenJS 
 
 ### Project Acceptance Process
 * Projects are required to present their proposal at a CPC meeting
-* The CPC may ask for changes to bring the project into better alignment with the OpenJS Foundation (adding a governance document to a repository or adopting a more stringent Code of Conduct, for example).
+* The CPC may ask for changes to bring the project into better alignment with the Foundation (adding a governance document to a repository or adopting a more stringent Code of Conduct, for example).
  * The project will need to make these changes in order to progress further.
 * Projects get accepted via a 2/3 supermajority vote of the CPC.
 * The proposal document will be finalized as a project charter. This charter document must be included in the project's main repository.
 * The CPC will determine the appropriate initial stage for the project. The project can apply for a different stage via the review process. 
 
 ## III. Stages - Definitions & Expectations
-Every OpenJS Foundation project has an associated maturity level. Proposed OpenJS Foundation projects should state their preferred maturity level. Projects of all maturities have access to OpenJS Foundation resources.
+Every Foundation project has an associated maturity level. Proposed Foundation projects should state their preferred maturity level. Projects of all maturities have access to Foundation resources.
 
-All OpenJS Foundation projects may attend CPC meetings and contribute work regardless of their stage. 
+All Foundation projects may attend CPC meetings and contribute work regardless of their stage. 
 
 *note: all stage names are tbd pending outcome of [#44](https://github.com/nodejs/bootstrap/issues/44#issuecomment-440026298)*
 
 ### At Large Projects (formerly 'Sandbox')
 **Definition** 
 
-At Large projects are projects which the CPC believes are, or have the potential to be, important to the ecosystem of Top-Level Projects or the JS ecosystem as a whole. They may be early-stage projects just getting started, or they may be long-established projects with minimal resource needs. The At Large stage provides a beneficial, neutral home for these projects in order to foster collaborative development and provide a path to deeper alignment with other OpenJS Foundation projects via the graduation process.
+At Large projects are projects which the CPC believes are, or have the potential to be, important to the ecosystem of Top-Level Projects or the JS ecosystem as a whole. They may be early-stage projects just getting started, or they may be long-established projects with minimal resource needs. The At Large stage provides a beneficial, neutral home for these projects in order to foster collaborative development and provide a path to deeper alignment with other Foundation projects via the graduation process.
 
 **Examples**
 
-1. New projects that are designed to extend one or more OpenJS Foundation projects with functionality or interoperability libraries. 
-1. Independent projects that fit the OpenJS Foundation mission and provide potential for a novel approach to existing functional areas (or are an attempt to meet an unfulfilled need).
-1. Projects commissioned or sanctioned by the OpenJS Foundation.
-1. Any project that realistically intends to join the OpenJS Foundation Incubation or Top Level Stages in the future and wishes to lay the foundations for that transition.
+1. New projects that are designed to extend one or more Foundation projects with functionality or interoperability libraries. 
+1. Independent projects that fit the Foundation mission and provide potential for a novel approach to existing functional areas (or are an attempt to meet an unfulfilled need).
+1. Projects commissioned or sanctioned by the Foundation.
+1. Any project that realistically intends to join the Foundation Incubation or Top Level Stages in the future and wishes to lay the foundations for that transition.
 
 **Expectations**
 
-End users should evaluate At Large projects with care, as this stage does not set requirements for community size, governance, or production readiness. At Large projects will receive minimal marketing support from the OpenJS Foundation. Projects will be reviewed on an annual basis; they may also request a status review by submitting a report to the CPC.
+End users should evaluate At Large projects with care, as this stage does not set requirements for community size, governance, or production readiness. At Large projects will receive minimal marketing support from the Foundation. Projects will be reviewed on an annual basis; they may also request a status review by submitting a report to the CPC.
 
 **Acceptance Criteria**
 
 To be considered for the At Large Stage, the project must meet the following requirements:
 * 2 CPC sponsors to champion the project & provide mentorship as needed
 * A presentation to at the meeting of the CPC
-* Adherence to the OpenJS Foundation IP Policy
+* Adherence to the Foundation IP Policy
 * Upon acceptance, At Large projects must list their status prominently on website/readme
 
 ### Growth Stage (formerly 'Incubating')
@@ -125,7 +125,7 @@ To graduate from At Large or Growth status, or for a new project to join as an I
  * Have a defined governing body of at least 5 or more members (owners and core maintainers), of which no more than 1/3 is affiliated with the same employer. In the case there are 5 governing members, 2 may be from the same employer. 
  * Have a documented and publicly accessible description of the project's governance, decision-making, and release processes.
  * Have a healthy number of committers from at least two organizations. A committer is defined as someone with the commit bit; i.e., someone who can accept contributions to some or all of the project.
- * Adopt the OpenJS Foundation Code of Conduct.
+ * Adopt the Foundation Code of Conduct.
  * Explicitly define a project governance and committer process. This is preferably laid out in a GOVERNANCE.md file and references a CONTRIBUTING.md and OWNERS.md file showing the current and emeritus committers.
  * Have a public list of project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the project website).
  * Other metrics as defined by the applying Project during the application process in cooperation with the CPC.
@@ -135,7 +135,7 @@ To graduate from At Large or Growth status, or for a new project to join as an I
 ### Emeritus Stage
 **Definition**
 
-Emeritus projects are projects which the maintainers feel have reached or are nearing end-of-life. Emeritus projects have contributed to the ecosystem, but are not necessarily recommended for modern development as there may be more actively maintained choices. The OpenJS Foundation appreciates the contributions of these projects and their communities, and the role they have played in moving the ecosystem forward. 
+Emeritus projects are projects which the maintainers feel have reached or are nearing end-of-life. Emeritus projects have contributed to the ecosystem, but are not necessarily recommended for modern development as there may be more actively maintained choices. The Foundation appreciates the contributions of these projects and their communities, and the role they have played in moving the ecosystem forward. 
 
 **Examples**
 


### PR DESCRIPTION
Now that we have a name, reading OpenJS Foundation has become rather repetitive :)

Per discussion in #126, this PR uses the useful legal pattern of writing a sentence around the first instance along the lines of:

...in the OpenJS Foundation, hereinafter referred to as the "Foundation".

The scope of a statement like this is limited to each document, so there won't be spillover in the larger corpus of OpenJS Foundation governance.