### PR TITLE
doc: update to reflect planned CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,10 +1,37 @@
 # Code of Conduct
 
-The [Node.js Code of Conduct][] applies to this team.
+The OpenJS Foundation and its member projects use the Contributor
+Covenant v1.4.1 as its Code of Conduct. Refer to the following
+for the full text:
 
-# Moderation Policy
+* [english](https://www.contributor-covenant.org/version/1/4/code-of-conduct)
+* [translations](https://www.contributor-covenant.org/translations)
 
-The [Node.js Moderation Policy][] applies to this team.
+Refer to the section on reporting and escalation in this document for the specific emails that can be used to report and esclate issues.
 
-[Node.js Code of Conduct]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
-[Node.js Moderation Policy]: https://github.com/nodejs/admin/blob/master/Moderation-Policy.md
+# Reporting
+
+## Project Spaces
+
+For reporting issues in spaces related to a member project please use the email provided by the project for reporting. Projects handle CoC issues related to the spaces that they maintain.  Projects maintainers commit to:
+
+* maintain the confidentiality with regard to the reporter of an incident
+* to participate in the path for escalation as outlined in
+  the section on Escalation when required.
+
+## Foundation Spaces
+For reporing issues in spaces managed by the OpenJS Foundation, for example, repositories within the OpenJS organization, use the email `report@openjsf.org`. The CrossProjectCouncil (CPC) is responsible for managing these reports and commits to:
+
+* maintain the confidentiality with regard to the reporter of an incident
+* to participate in the path for escalation as outlined in
+  the section on Escalation when required.
+
+# Escalation
+
+The OpenJS Foundation maintains a Code of Conduct Panel (CoCP). This is a cross-foundation team established to managed escalation when a reporter believes that a report to a member project or the CPC has not been properly handled. In order to escalate to the CoCP send an email to `coc-escalation@openjsf.org`.
+
+For more information refer to the full
+[Code of Conduct governance document}(https://github.com/openjs-foundation/bootstrap/blob/master/proposals/stage-1/CODE_OF_CONDUCT/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).
+
+
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -28,7 +28,7 @@ For reporting issues in spaces managed by the OpenJS Foundation, for example, re
 
 # Escalation
 
-The OpenJS Foundation maintains a Code of Conduct Panel (CoCP). This is a cross-foundation team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled. In order to escalate to the CoCP send an email to `coc-escalation@openjsf.org`.
+The OpenJS Foundation maintains a Code of Conduct Panel (CoCP). This is a foundation-wide team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled. In order to escalate to the CoCP send an email to `coc-escalation@openjsf.org`.
 
 For more information, refer to the full
 [Code of Conduct governance document](https://github.com/openjs-foundation/bootstrap/blob/master/proposals/stage-1/CODE_OF_CONDUCT/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -28,10 +28,10 @@ For reporing issues in spaces managed by the OpenJS Foundation, for example, rep
 
 # Escalation
 
-The OpenJS Foundation maintains a Code of Conduct Panel (CoCP). This is a cross-foundation team established to managed escalation when a reporter believes that a report to a member project or the CPC has not been properly handled. In order to escalate to the CoCP send an email to `coc-escalation@openjsf.org`.
+The OpenJS Foundation maintains a Code of Conduct Panel (CoCP). This is a cross-foundation team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled. In order to escalate to the CoCP send an email to `coc-escalation@openjsf.org`.
 
 For more information refer to the full
-[Code of Conduct governance document}(https://github.com/openjs-foundation/bootstrap/blob/master/proposals/stage-1/CODE_OF_CONDUCT/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).
+[Code of Conduct governance document](https://github.com/openjs-foundation/bootstrap/blob/master/proposals/stage-1/CODE_OF_CONDUCT/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).
 
 
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -20,7 +20,7 @@ For reporting issues in spaces related to a member project please use the email 
   the section on Escalation when required.
 
 ## Foundation Spaces
-For reporting issues in spaces managed by the OpenJS Foundation, for example, repositories within the OpenJS organization, use the email `report@openjsf.org`. The CrossProjectCouncil (CPC) is responsible for managing these reports and commits to:
+For reporting issues in spaces managed by the OpenJS Foundation, for example, repositories within the OpenJS organization, use the email `report@openjsf.org`. The Cross Project Council (CPC) is responsible for managing these reports and commits to:
 
 * maintain the confidentiality with regard to the reporter of an incident
 * to participate in the path for escalation as outlined in

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -20,7 +20,7 @@ For reporting issues in spaces related to a member project please use the email 
   the section on Escalation when required.
 
 ## Foundation Spaces
-For reporting issues in spaces managed by the OpenJS Foundation, for example, repositories within the OpenJS organization, use the email `report@openjsf.org`. The Cross Project Council (CPC) is responsible for managing these reports and commits to:
+For reporting issues in spaces managed by the OpenJS Foundation, for example, repositories within the OpenJS organization, use the email `report@lists.openjsf.org`. The Cross Project Council (CPC) is responsible for managing these reports and commits to:
 
 * maintain the confidentiality with regard to the reporter of an incident
 * to participate in the path for escalation as outlined in
@@ -28,7 +28,7 @@ For reporting issues in spaces managed by the OpenJS Foundation, for example, re
 
 # Escalation
 
-The OpenJS Foundation maintains a Code of Conduct Panel (CoCP). This is a foundation-wide team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled. In order to escalate to the CoCP send an email to `coc-escalation@openjsf.org`.
+The OpenJS Foundation maintains a Code of Conduct Panel (CoCP). This is a foundation-wide team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled. In order to escalate to the CoCP send an email to `"coc-escalation@lists.openjsf.org`.
 
 For more information, refer to the full
 [Code of Conduct governance document](https://github.com/openjs-foundation/bootstrap/blob/master/proposals/stage-1/CODE_OF_CONDUCT/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,7 +7,7 @@ for the full text:
 * [english](https://www.contributor-covenant.org/version/1/4/code-of-conduct)
 * [translations](https://www.contributor-covenant.org/translations)
 
-Refer to the section on reporting and escalation in this document for the specific emails that can be used to report and esclate issues.
+Refer to the section on reporting and escalation in this document for the specific emails that can be used to report and escalate issues.
 
 # Reporting
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -20,7 +20,7 @@ For reporting issues in spaces related to a member project please use the email 
   the section on Escalation when required.
 
 ## Foundation Spaces
-For reporing issues in spaces managed by the OpenJS Foundation, for example, repositories within the OpenJS organization, use the email `report@openjsf.org`. The CrossProjectCouncil (CPC) is responsible for managing these reports and commits to:
+For reporting issues in spaces managed by the OpenJS Foundation, for example, repositories within the OpenJS organization, use the email `report@openjsf.org`. The CrossProjectCouncil (CPC) is responsible for managing these reports and commits to:
 
 * maintain the confidentiality with regard to the reporter of an incident
 * to participate in the path for escalation as outlined in

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -30,7 +30,7 @@ For reporting issues in spaces managed by the OpenJS Foundation, for example, re
 
 The OpenJS Foundation maintains a Code of Conduct Panel (CoCP). This is a cross-foundation team established to manage escalation when a reporter believes that a report to a member project or the CPC has not been properly handled. In order to escalate to the CoCP send an email to `coc-escalation@openjsf.org`.
 
-For more information refer to the full
+For more information, refer to the full
 [Code of Conduct governance document](https://github.com/openjs-foundation/bootstrap/blob/master/proposals/stage-1/CODE_OF_CONDUCT/FOUNDATION_CODE_OF_CONDUCT_REQUIREMENTS.md).
 
 


### PR DESCRIPTION
Update to reflect the planned CoC process and
emails.

Once this in place we'll ask that projects refer to it
as the master CoC that applies to their project in each of the
places they refer to a CoC.