### PR TITLE
Add stage 3 CPC Charter to the proposals README

### DIFF
--- a/proposals/README.md
+++ b/proposals/README.md
@@ -19,7 +19,7 @@ There are currently no Stage 2 proposals.
 ## Stage 3
 
 * [Community Board representation](./stage-3/COMMUNITY_BOARD_REPRESENTATION)
-* [CPC Charter](https://github.com/openjs-foundation/bootstrap/tree/master/proposals/stage-3/CPC_CHARTER)
+* [CPC Charter](./proposals/stage-3/CPC_CHARTER)
 * [Expectations](./stage-3/EXPECTATIONS)
 * [Governance](./stage-3/GOVERNANCE)
 * [Individual Membership program](./stage-3/INDIVIDUAL_MEMBERSHIP)

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -19,6 +19,7 @@ There are currently no Stage 2 proposals.
 ## Stage 3
 
 * [Community Board representation](./stage-3/COMMUNITY_BOARD_REPRESENTATION)
+* [CPC Charter](https://github.com/openjs-foundation/bootstrap/tree/master/proposals/stage-3/CPC_CHARTER)
 * [Expectations](./stage-3/EXPECTATIONS)
 * [Governance](./stage-3/GOVERNANCE)
 * [Individual Membership program](./stage-3/INDIVIDUAL_MEMBERSHIP)


### PR DESCRIPTION
Link removed from the stage 2 category in https://github.com/openjs-foundation/bootstrap/commit/ead513e8ddc68abab97ea147c1a070979eb06a85, adding to stage 3. 👍